### PR TITLE
Fix windows compatibility with command line '\r\n'

### DIFF
--- a/quest.go
+++ b/quest.go
@@ -130,7 +130,7 @@ func (q *Question) wait() error {
 	if q.choices {
 		q.print(q.color("?"), " ", "Answer", " ")
 	}
-	r, err := reader.ReadLine()
+	r, _, err := reader.ReadLine()
 	if err != nil {
 		return err
 	}

--- a/quest.go
+++ b/quest.go
@@ -130,11 +130,11 @@ func (q *Question) wait() error {
 	if q.choices {
 		q.print(q.color("?"), " ", "Answer", " ")
 	}
-	r, err := reader.ReadString('\n')
+	r, err := reader.ReadLine()
 	if err != nil {
 		return err
 	}
-	q.response = r[:len(r)-1]
+	q.response = string(r)
 	if abort := q.abort(q.response); abort.value != "" {
 		abort.status = true
 		return nil


### PR DESCRIPTION
The fix is to use ReadLine instead of ReadString('\n')
since according to the documentation ReadLine trims both
\r and \n from the line.

This fixes my issue in #2 